### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides browser automation capabilities using [Playwright](https://playwright.dev). This server enables LLMs to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models.
 
+<a href="https://glama.ai/mcp/servers/@furugen/playwright-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@furugen/playwright-mcp/badge" alt="Playwright MCP server" />
+</a>
+
 ### Key Features
 
 - **Fast and lightweight**. Uses Playwright's accessibility tree, not pixel-based input.


### PR DESCRIPTION
This PR adds a badge for the [Playwright MCP](https://glama.ai/mcp/servers/@furugen/playwright-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@furugen/playwright-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@furugen/playwright-mcp/badge" alt="Playwright MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.